### PR TITLE
Little bug fixes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ import { HighscoreComponent } from './highscore/highscore.component';
 import { MenuComponent } from './menu/menu.component';
 
 const routes: Routes = [
-  { path: 'level/:level', component: LevelComponent },
+  { path: 'level/:level/:newGame', component: LevelComponent },
   { path: 'highscore/:level', component: HighscoreComponent },
   { path: 'menu', component: MenuComponent },
   { path: '', redirectTo: '/menu', pathMatch: 'full' },
@@ -16,4 +16,4 @@ const routes: Routes = [
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule {}
+export class AppRoutingModule { }

--- a/src/app/level/level.component.scss
+++ b/src/app/level/level.component.scss
@@ -74,6 +74,7 @@ Overall Section
   position: fixed;
   text-align: center;
   width: 100%;
+  z-index: 3;
   @media (max-width: 767px) {
     bottom: 43px;
     padding: 5px 0 10px 0;

--- a/src/app/level/level.component.spec.ts
+++ b/src/app/level/level.component.spec.ts
@@ -43,12 +43,14 @@ describe('LevelComponent (shallow)', () => {
       level: testLevel,
       levelId: 1,
       levelTime: 234000,
-      moves: 567
+      moves: 567,
+      isWin: false
     };
     localStorage.setItem('savegame', JSON.stringify(savegame));
     const route = new ActivatedRoute();
     route.params = of({
-      level: 1
+      level: 1,
+      newGame: 'false'
     });
     const lvl = new LevelComponent(levelService, highscoreService, null, route, pathFinderService);
     lvl.ngOnInit();
@@ -64,7 +66,8 @@ describe('LevelComponent (shallow)', () => {
     const pathFinderService = new PathFinderService();
     const route = new ActivatedRoute();
     route.params = of({
-      level: 0
+      level: 0,
+      newGame: 'true'
     });
     const lvl = new LevelComponent(levelService, highscoreService, null, route, pathFinderService);
     lvl.ngOnInit();
@@ -296,7 +299,8 @@ describe('LevelComponent', () => {
       level: testLevel,
       levelId: 123,
       levelTime: 456000,
-      moves: 789
+      moves: 789,
+      isWin: false
     };
     localStorage.setItem('savegame', JSON.stringify(savegame));
     expect(component.loadSaveGame()).toBeFalsy();

--- a/src/app/level/level.component.ts
+++ b/src/app/level/level.component.ts
@@ -32,6 +32,7 @@ export class LevelComponent implements OnInit, OnDestroy {
   pathToWalkOn: Coordinate[];
   contentWidth: number;
   centerContent: boolean;
+  hasHighscoreEntry: boolean;
 
   constructor(
     private levelService: LevelService,
@@ -68,13 +69,14 @@ export class LevelComponent implements OnInit, OnDestroy {
 
   checkWin() {
     this.isWin = this.level.tiles.every(line => !line.some(tile => tile === Tile.target || tile === Tile.box));
-    if (this.isWin) {
+    if (this.isWin && !this.hasHighscoreEntry) {
       console.log('Player has won.');
       this.highscoreService.addEntry(this.levelId, {
         name: 'Player',
         moves: this.counter,
         levelTime: this.levelTime
       });
+      this.hasHighscoreEntry = true;
     }
   }
 
@@ -146,7 +148,8 @@ export class LevelComponent implements OnInit, OnDestroy {
       levelTime: this.levelTime,
       level: this.level,
       history: this.history,
-      moves: this.counter
+      moves: this.counter,
+      isWin: this.isWin
     };
 
     localStorage.setItem('savegame', JSON.stringify(saveGame));
@@ -168,6 +171,8 @@ export class LevelComponent implements OnInit, OnDestroy {
     this.levelTime = saveGame.levelTime;
     this.counter = saveGame.moves;
     this.levelStarted = false;
+    this.isWin = saveGame.isWin;
+    this.hasHighscoreEntry = this.isWin;
     return true;
   }
 

--- a/src/app/level/level.component.ts
+++ b/src/app/level/level.component.ts
@@ -44,9 +44,10 @@ export class LevelComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.routeParameterSubscription = this.route.paramMap.subscribe(value => {
       this.levelId = Number.parseInt(value.get('level'), 10);
+      const isNewGame = value.get('newGame').toLowerCase() === 'true';
       console.log('Level: ' + this.levelId);
       this.internalLevel = this.levelService.getLevel(this.levelId ? this.levelId : 0);
-      if (!this.loadSaveGame()) {
+      if (isNewGame || !this.loadSaveGame()) {
         this.reset();
       }
       this.setContentWidth();

--- a/src/app/level/level.component.ts
+++ b/src/app/level/level.component.ts
@@ -45,7 +45,7 @@ export class LevelComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.routeParameterSubscription = this.route.paramMap.subscribe(value => {
       this.levelId = Number.parseInt(value.get('level'), 10);
-      const isNewGame = value.get('newGame').toLowerCase() === 'true';
+      const isNewGame = value.get('newGame') ? value.get('newGame').toLowerCase() === 'true' : true;
       console.log('Level: ' + this.levelId);
       this.internalLevel = this.levelService.getLevel(this.levelId ? this.levelId : 0);
       if (isNewGame || !this.loadSaveGame()) {

--- a/src/app/menu/menu.component.spec.ts
+++ b/src/app/menu/menu.component.spec.ts
@@ -22,7 +22,8 @@ describe('MenuComponent with save game', () => {
       levelTime: 456000,
       levelId: 789,
       level: undefined,
-      history: []
+      history: [],
+      isWin: false
     };
     localStorage.setItem('savegame', JSON.stringify(savegame));
     fixture = TestBed.createComponent(MenuComponent);
@@ -30,7 +31,7 @@ describe('MenuComponent with save game', () => {
     fixture.detectChanges();
     expect(component.canContinue).toBeTruthy();
     component.continueGame();
-    expect(spy).toHaveBeenCalledWith(['level', savegame.levelId]);
+    expect(spy).toHaveBeenCalledWith(['level', savegame.levelId, false]);
   }));
 });
 
@@ -60,7 +61,7 @@ describe('MenuComponent', () => {
   it('should start new game', inject([Router], router => {
     const spy = spyOn(router, 'navigate');
     component.newGame();
-    expect(spy).toHaveBeenCalledWith(['level', 0]);
+    expect(spy).toHaveBeenCalledWith(['level', 0, true]);
   }));
 
   it('should show credits', inject([Router], router => {

--- a/src/app/menu/menu.component.ts
+++ b/src/app/menu/menu.component.ts
@@ -23,14 +23,14 @@ export class MenuComponent implements OnInit {
     this.savegame = JSON.parse(saveGameSerialized) as Savegame;
   }
 
-  ngOnInit() {}
+  ngOnInit() { }
 
   continueGame(): void {
-    this.router.navigate(['level', this.savegame.levelId]);
+    this.router.navigate(['level', this.savegame.levelId, false]);
   }
 
   newGame(): void {
-    this.router.navigate(['level', 0]);
+    this.router.navigate(['level', 0, true]);
   }
 
   showCredits(): void {

--- a/src/app/models/savegame.ts
+++ b/src/app/models/savegame.ts
@@ -6,4 +6,5 @@ export class Savegame {
   level: Level;
   moves: number;
   history: Level[];
+  isWin: boolean;
 }

--- a/src/app/services/level.service.spec.ts
+++ b/src/app/services/level.service.spec.ts
@@ -44,12 +44,12 @@ describe('LevelService', () => {
 
     // Simple increment
     service.getNextLevel();
-    expect(spy).toHaveBeenCalledWith(['level', 1]);
+    expect(spy).toHaveBeenCalledWith(['level', 1, true]);
     spy.calls.reset();
 
     // Decrement with wrap around
     service.getPreviousLevel();
-    expect(spy).toHaveBeenCalledWith(['level', service.getLevelCount() - 1]);
+    expect(spy).toHaveBeenCalledWith(['level', service.getLevelCount() - 1, true]);
     spy.calls.reset();
 
     // Set last level
@@ -57,11 +57,11 @@ describe('LevelService', () => {
 
     // Increment with wrap around
     service.getNextLevel();
-    expect(spy).toHaveBeenCalledWith(['level', 0]);
+    expect(spy).toHaveBeenCalledWith(['level', 0, true]);
     spy.calls.reset();
 
     // Simple decrement
     service.getPreviousLevel();
-    expect(spy).toHaveBeenCalledWith(['level', service.getLevelCount() - 2]);
+    expect(spy).toHaveBeenCalledWith(['level', service.getLevelCount() - 2, true]);
   }));
 });

--- a/src/app/services/level.service.ts
+++ b/src/app/services/level.service.ts
@@ -33,11 +33,11 @@ export class LevelService {
   }
 
   getNextLevel(): void {
-    this.router.navigate(['level', this.index === this.getLevelCount() - 1 ? 0 : this.index + 1]);
+    this.router.navigate(['level', this.index === this.getLevelCount() - 1 ? 0 : this.index + 1, true]);
   }
 
   getPreviousLevel(): void {
-    this.router.navigate(['level', (!this.index ? this.getLevelCount() : this.index) - 1]);
+    this.router.navigate(['level', (!this.index ? this.getLevelCount() : this.index) - 1, true]);
   }
 
   loadLevel(serializedLevel: string, name: string): Level {


### PR DESCRIPTION
fixes for the following bugs:
- the winner message is now in the foreground (cursor had higher z-index)
- new Game always loads an empty game, does not load from local storage
- an highscore entry is only made once when winning a game
- when a game that has been won before is loaded with 'continue' there won't be another highscore entry